### PR TITLE
inertia scrolling: Remove static modifier in ScrollView

### DIFF
--- a/core/java/android/widget/ScrollView.java
+++ b/core/java/android/widget/ScrollView.java
@@ -89,7 +89,7 @@ public class ScrollView extends FrameLayout {
 
     private final Rect mTempRect = new Rect();
     @UnsupportedAppUsage
-    private static OverScroller mScroller;
+    private OverScroller mScroller;
     /**
      * Tracks the state of the top edge glow.
      *
@@ -142,7 +142,7 @@ public class ScrollView extends FrameLayout {
      * Determines speed during touch scrolling
      */
     @UnsupportedAppUsage
-    private static VelocityTracker mVelocityTracker;
+    private VelocityTracker mVelocityTracker;
 
     /**
      * When set to true, the scroll view measure its child to make it fill the currently


### PR DESCRIPTION
When ScrollView is too complicated, a child ScrollView inside another parent ScrollView. The static modifier makes some operations wrong (acceleration, velocity when finger fling). Inertia scrolling will re-working.

Follow my commit here: https://review.havoc-os.com/c/Havoc-OS/android_frameworks_base/+/122